### PR TITLE
feat(oauth): Fi-38 Add slack v2 OAuth2 to CMS

### DIFF
--- a/@core/cms/src/app.controller.ts
+++ b/@core/cms/src/app.controller.ts
@@ -48,7 +48,7 @@ export class AppController {
   @MessagePattern("oauth")
   async handleOAuth(message: any) {
     // TODO: Add JWT and pass params
-    const url = this.externalAuthIntegrationService.authenticate("oauth-airtable-v1");
+    const url = this.externalAuthIntegrationService.authenticate("oauth-slack-v2");
     return url;
   }
 

--- a/@core/cms/src/app.controller.ts
+++ b/@core/cms/src/app.controller.ts
@@ -48,7 +48,7 @@ export class AppController {
   @MessagePattern("oauth")
   async handleOAuth(message: any) {
     // TODO: Add JWT and pass params
-    const url = this.externalAuthIntegrationService.authenticate("oauth-slack-v2");
+    const url = this.externalAuthIntegrationService.authenticate(message);
     return url;
   }
 

--- a/@core/cms/src/external-auth-integration/auth-provider.factory.ts
+++ b/@core/cms/src/external-auth-integration/auth-provider.factory.ts
@@ -3,6 +3,7 @@ import { IOAuth } from "./auth-providers/oauth2/interface/ioauth.interface";
 import { GoogleV2OAuth2Service } from "./auth-providers/oauth2/google/v2/google.v2.service";
 import { GithubV1OAuth2Service } from "./auth-providers/oauth2/github/v1/github.v1.service";
 import { AirtableV1OAuth2Service } from "./auth-providers/oauth2/airtable/v1/airtable.v1.service";
+import { SlackV2OAuth2Service } from "./auth-providers/oauth2/slack/v2/slack.v2.service";
 
 @Injectable()
 export class AuthProviderFactory {
@@ -11,11 +12,13 @@ export class AuthProviderFactory {
   constructor(
     private googleV2OAuth2Service: GoogleV2OAuth2Service,
     private githubV1OAuth2Service: GithubV1OAuth2Service,
-    private airtableV1OAuth2Service: AirtableV1OAuth2Service
+    private airtableV1OAuth2Service: AirtableV1OAuth2Service,
+    private slackV2OAuth2Service: SlackV2OAuth2Service,
   ) {
     this.registerProvider("oauth-google-v2", this.googleV2OAuth2Service);
     this.registerProvider("oauth-github-v1", this.githubV1OAuth2Service);
     this.registerProvider("oauth-airtable-v1", this.airtableV1OAuth2Service);
+    this.registerProvider("oauth-slack-v2", this.slackV2OAuth2Service);
   }
 
   private registerProvider(key: string, provider: IOAuth) {

--- a/@core/cms/src/external-auth-integration/auth-providers/oauth2/oauth2.module.ts
+++ b/@core/cms/src/external-auth-integration/auth-providers/oauth2/oauth2.module.ts
@@ -8,6 +8,8 @@ import { GithubV1OAuth2Service } from "./github/v1/github.v1.service";
 import { GithubV1OAuth2Config } from "./github/v1/github.v1.config";
 import { AirtableV1OAuth2Service } from "./airtable/v1/airtable.v1.service";
 import { AirtableV1OAuth2Config } from "./airtable/v1/airtable.v1.config";
+import { SlackV2OAuth2Service } from "./slack/v2/slack.v2.service";
+import { SlackV2OAuth2Config } from "./slack/v2/slack.v2.config";
 
 @Module({
   imports: [EncryptionDecryptionModule, HttpModule, CacheModule.register()],
@@ -26,6 +28,11 @@ import { AirtableV1OAuth2Config } from "./airtable/v1/airtable.v1.config";
     {
       provide: "AirtableV1OAuth2Config",
       useFactory: () => new AirtableV1OAuth2Config().oAuth2Config,
+    },
+    SlackV2OAuth2Service,
+    {
+      provide: "SlackV2OAuth2Config",
+      useFactory: () => new SlackV2OAuth2Config().oAuth2Config,
     },
   ],
   exports: [GoogleV2OAuth2Service, GithubV1OAuth2Service, AirtableV1OAuth2Service],

--- a/@core/cms/src/external-auth-integration/auth-providers/oauth2/oauth2.module.ts
+++ b/@core/cms/src/external-auth-integration/auth-providers/oauth2/oauth2.module.ts
@@ -35,6 +35,6 @@ import { SlackV2OAuth2Config } from "./slack/v2/slack.v2.config";
       useFactory: () => new SlackV2OAuth2Config().oAuth2Config,
     },
   ],
-  exports: [GoogleV2OAuth2Service, GithubV1OAuth2Service, AirtableV1OAuth2Service],
+  exports: [GoogleV2OAuth2Service, GithubV1OAuth2Service, AirtableV1OAuth2Service, SlackV2OAuth2Service],
 })
 export class OAuth2Module {}

--- a/@core/cms/src/external-auth-integration/auth-providers/oauth2/slack/v2/slack.v2.config.ts
+++ b/@core/cms/src/external-auth-integration/auth-providers/oauth2/slack/v2/slack.v2.config.ts
@@ -22,10 +22,6 @@ export class SlackV2OAuth2Config {
         verifyTokenUrl: "https://slack.com/api/auth.test",
         refreshTokenUrl: "https://slack.com/api/oauth.v2.access",
         tokenRefreshBuffer: 43200, // 12 hours
-        callbackUrlParams: {
-          response_type: "code",
-          access_type: "offline",
-        },
       },
     };
   }

--- a/@core/cms/src/external-auth-integration/auth-providers/oauth2/slack/v2/slack.v2.config.ts
+++ b/@core/cms/src/external-auth-integration/auth-providers/oauth2/slack/v2/slack.v2.config.ts
@@ -14,14 +14,14 @@ export class SlackV2OAuth2Config {
         id: process.env.SLACK_V2_OAUTH2_CLIENT_ID,
         secret: process.env.SLACK_V2_OAUTH2_CLIENT_SECRET,
       },
-      scope: ["users:read"], // TODO: Slack scopes
+      scope: ["email"], // TODO: Slack scopes
       provider: {
         authorizeUrl: "https://slack.com/oauth/v2/authorize",
         tokenUrl: "https://slack.com/api/oauth.v2.exchange",
         callbackUrl: `${process.env.HOST_CONFIG_URL}/oauth/callback`,
         verifyTokenUrl: "https://slack.com/api/auth.test",
         refreshTokenUrl: "https://slack.com/api/oauth.v2.exchange",
-        tokenRefreshBuffer: 7776000, // 90 days
+        tokenRefreshBuffer: 43200, // 12 hours
         callbackUrlParams: {
           response_type: "code",
           access_type: "offline",

--- a/@core/cms/src/external-auth-integration/auth-providers/oauth2/slack/v2/slack.v2.config.ts
+++ b/@core/cms/src/external-auth-integration/auth-providers/oauth2/slack/v2/slack.v2.config.ts
@@ -14,15 +14,16 @@ export class SlackV2OAuth2Config {
         id: process.env.SLACK_V2_OAUTH2_CLIENT_ID,
         secret: process.env.SLACK_V2_OAUTH2_CLIENT_SECRET,
       },
-      scope: ["email"], // TODO: Slack scopes
+      scope: [],
       provider: {
         authorizeUrl: "https://slack.com/oauth/v2/authorize",
-        tokenUrl: "https://slack.com/api/oauth.v2.exchange",
+        tokenUrl: "https://slack.com/api/oauth.v2.access",
         callbackUrl: `${process.env.HOST_CONFIG_URL}/oauth/callback`,
         verifyTokenUrl: "https://slack.com/api/auth.test",
-        refreshTokenUrl: "https://slack.com/api/oauth.v2.exchange",
+        refreshTokenUrl: "https://slack.com/api/oauth.v2.access",
         tokenRefreshBuffer: 43200, // 12 hours
         callbackUrlParams: {
+          user_scope: "openid,email,profile", // We are requesting user token, so we need to pass scopes to user_scope
           response_type: "code",
           access_type: "offline",
         },

--- a/@core/cms/src/external-auth-integration/auth-providers/oauth2/slack/v2/slack.v2.config.ts
+++ b/@core/cms/src/external-auth-integration/auth-providers/oauth2/slack/v2/slack.v2.config.ts
@@ -14,7 +14,7 @@ export class SlackV2OAuth2Config {
         id: process.env.SLACK_V2_OAUTH2_CLIENT_ID,
         secret: process.env.SLACK_V2_OAUTH2_CLIENT_SECRET,
       },
-      scope: [],
+      scope: ["openid", "email", "profile"],
       provider: {
         authorizeUrl: "https://slack.com/oauth/v2/authorize",
         tokenUrl: "https://slack.com/api/oauth.v2.access",
@@ -23,7 +23,6 @@ export class SlackV2OAuth2Config {
         refreshTokenUrl: "https://slack.com/api/oauth.v2.access",
         tokenRefreshBuffer: 43200, // 12 hours
         callbackUrlParams: {
-          user_scope: "openid,email,profile", // We are requesting user token, so we need to pass scopes to user_scope
           response_type: "code",
           access_type: "offline",
         },

--- a/@core/cms/src/external-auth-integration/auth-providers/oauth2/slack/v2/slack.v2.config.ts
+++ b/@core/cms/src/external-auth-integration/auth-providers/oauth2/slack/v2/slack.v2.config.ts
@@ -1,0 +1,32 @@
+import { Injectable } from "@nestjs/common";
+import { IOAuth2Config } from "~/external-auth-integration/auth-providers/oauth2/@types";
+
+/**
+ * Service for configuring Slack V2 OAuth2.
+ */
+@Injectable()
+export class SlackV2OAuth2Config {
+  public oAuth2Config: IOAuth2Config;
+
+  constructor() {
+    this.oAuth2Config = {
+      credentials: {
+        id: process.env.SLACK_V2_OAUTH2_CLIENT_ID,
+        secret: process.env.SLACK_V2_OAUTH2_CLIENT_SECRET,
+      },
+      scope: ["users:read"], // TODO: Slack scopes
+      provider: {
+        authorizeUrl: "https://slack.com/oauth/v2/authorize",
+        tokenUrl: "https://slack.com/api/oauth.v2.exchange",
+        callbackUrl: `${process.env.HOST_CONFIG_URL}/oauth/callback`,
+        verifyTokenUrl: "https://slack.com/api/auth.test",
+        refreshTokenUrl: "https://slack.com/api/oauth.v2.exchange",
+        tokenRefreshBuffer: 7776000, // 90 days
+        callbackUrlParams: {
+          response_type: "code",
+          access_type: "offline",
+        },
+      },
+    };
+  }
+}

--- a/@core/cms/src/external-auth-integration/auth-providers/oauth2/slack/v2/slack.v2.service.ts
+++ b/@core/cms/src/external-auth-integration/auth-providers/oauth2/slack/v2/slack.v2.service.ts
@@ -1,0 +1,109 @@
+import { Injectable, Inject, Logger, Res, HttpException, HttpStatus } from "@nestjs/common";
+import { HttpService } from "@nestjs/axios";
+import { EncryptionDecryptionService } from "~/encryption-decryption/encryption-decryption.service";
+import { IOAuth } from "~/external-auth-integration/auth-providers/oauth2/interface/ioauth.interface";
+import {
+  OAuth2StateProcessor,
+  exchangeCodeForToken,
+  verifyToken,
+  refreshToken,
+  createOAuth2Url,
+} from "~/external-auth-integration/utils";
+import { IOAuth2Config, IOAuth2State, TokenVerificationResponse } from "~/external-auth-integration/auth-providers/oauth2/@types";
+
+/**
+ * Service to handle Slack V2 OAuth2 authentication.
+ */
+@Injectable()
+export class SlackV2OAuth2Service implements IOAuth {
+  constructor(
+    @Inject("SlackV2OAuth2Config") private readonly config: IOAuth2Config,
+    private readonly encryptionDecryptionService: EncryptionDecryptionService,
+    private readonly httpService: HttpService,
+  ) {}
+
+  /**
+   * Builds and returns the authentication URL for Google OAuth.
+   * @returns {Promise<string>} The Google OAuth URL.
+   */
+  async authenticate(): Promise<string> {
+    const encodedState = await this.buildState();
+    const url = createOAuth2Url(this.config, { state: encodedState }, "authorize");
+
+    Logger.log(`Redirecting to Slack OAuth URL: ${url}`);
+    return url;
+  }
+
+  /**
+   * Handles the OAuth callback and exchanges the code for a token.
+   * @param {any} query - The query parameters from the callback request.
+   * @param {any} res - The response object.
+   */
+  async handleCallback(query: any, @Res() res: any) {
+    try {
+      if (!query || !query.code) {
+        Logger.error("No code received", "SlackV2OAuth2Service");
+        throw new HttpException("No code received", HttpStatus.BAD_REQUEST);
+      }
+
+      const tokenResponse = await exchangeCodeForToken(this.httpService, this.config, query.code);
+
+      // TODO: Slack needs two steps to get a long-lived token
+      // First, use the code to exchange for a short-lived token
+      // Then, use the short-lived token to exchange for a long-lived token
+
+      res.status(HttpStatus.OK).json(tokenResponse);
+    } catch (error) {
+      Logger.error("Error exchanging code for token", error);
+      throw new HttpException("Error exchanging code for token", HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  /**
+   * Refreshes the access token using the refresh token.
+   * @param _refreshToken - The refresh token.
+   */
+  refreshToken(_refreshToken: string): Promise<any> {
+    return refreshToken(this.httpService, this.config, _refreshToken);
+  }
+
+  /**
+   * Verifies the access token.
+   * @param _accessToken
+   * @returns {Promise<any>} The response from the token verification endpoint.
+   */
+  async verifyToken(_accessToken: string): Promise<TokenVerificationResponse> {
+    try {
+      const verificationResponse = await verifyToken(this.httpService, this.config, _accessToken);
+      return {
+        isValid: true,
+        expiresIn: verificationResponse.expires_in,
+        scopes: verificationResponse.scope.split(" "),
+      } as TokenVerificationResponse;
+    } catch (error) {
+      Logger.error("Token verification failed", error);
+      return { isValid: false };
+    }
+  }
+
+  /**
+   * Builds the state parameter for OAuth authentication.
+   * @private
+   * @returns {Promise<string>} The base64 URL-encoded state.
+   */
+  private async buildState(): Promise<string> {
+    const oAuth2State: IOAuth2State = {
+      userId: "aaaa", // TODO: Replace with real user ID
+      providerInfo: {
+        provider: "slack",
+        version: "v2",
+      },
+    };
+
+    return new OAuth2StateProcessor(oAuth2State, this.encryptionDecryptionService)
+      .stringify()
+      .then((p) => p.encrypt())
+      .then((p) => p.toBase64())
+      .then((p) => p.getResult());
+  }
+}

--- a/@core/cms/src/external-auth-integration/auth-providers/oauth2/slack/v2/slack.v2.service.ts
+++ b/@core/cms/src/external-auth-integration/auth-providers/oauth2/slack/v2/slack.v2.service.ts
@@ -48,10 +48,6 @@ export class SlackV2OAuth2Service implements IOAuth {
 
       const tokenResponse = await exchangeCodeForToken(this.httpService, this.config, query.code);
 
-      // TODO: Slack needs two steps to get a long-lived token
-      // First, use the code to exchange for a short-lived token
-      // Then, use the short-lived token to exchange for a long-lived token
-
       res.status(HttpStatus.OK).json(tokenResponse);
     } catch (error) {
       Logger.error("Error exchanging code for token", error);

--- a/@core/cms/src/external-auth-integration/auth-providers/oauth2/slack/v2/slack.v2.service.ts
+++ b/@core/cms/src/external-auth-integration/auth-providers/oauth2/slack/v2/slack.v2.service.ts
@@ -28,7 +28,11 @@ export class SlackV2OAuth2Service implements IOAuth {
    */
   async authenticate(): Promise<string> {
     const encodedState = await this.buildState();
-    const url = createOAuth2Url(this.config, { state: encodedState }, "authorize");
+    // we are requesting user token, so we need to pass scopes to user_scope
+    const url = createOAuth2Url(this.config, {
+      state: encodedState,
+      scope: undefined
+    }, "authorize");
 
     Logger.log(`Redirecting to Slack OAuth URL: ${url}`);
     return url;

--- a/@core/cms/src/external-auth-integration/auth-providers/oauth2/slack/v2/slack.v2.service.ts
+++ b/@core/cms/src/external-auth-integration/auth-providers/oauth2/slack/v2/slack.v2.service.ts
@@ -24,14 +24,15 @@ export class SlackV2OAuth2Service implements IOAuth {
 
   /**
    * Builds and returns the authentication URL for Google OAuth.
-   * @returns {Promise<string>} The Google OAuth URL.
+   * @returns {Promise<string>} The Slack OAuth URL.
    */
   async authenticate(): Promise<string> {
     const encodedState = await this.buildState();
     // we are requesting user token, so we need to pass scopes to user_scope
     const url = createOAuth2Url(this.config, {
       state: encodedState,
-      scope: undefined
+      scope: "",
+      user_scope: this.config.scope.join(","),
     }, "authorize");
 
     Logger.log(`Redirecting to Slack OAuth URL: ${url}`);

--- a/@core/cms/src/external-auth-integration/utils/index.ts
+++ b/@core/cms/src/external-auth-integration/utils/index.ts
@@ -81,6 +81,9 @@ export function createOAuth2Url(
     throw new Error(`Invalid OAuth2 configuration - '${urlType}Url' is required`);
   }
 
+  // remove the params with undefined values
+  Object.keys(params).forEach(key => params[key] === undefined && delete params[key])
+  Logger.debug("Params", params, "OAuth2Utils");
   const url = new URL(baseUrl);
   const searchParams = new URLSearchParams(params);
   url.search = searchParams.toString();

--- a/@core/cms/src/external-auth-integration/utils/index.ts
+++ b/@core/cms/src/external-auth-integration/utils/index.ts
@@ -81,8 +81,6 @@ export function createOAuth2Url(
     throw new Error(`Invalid OAuth2 configuration - '${urlType}Url' is required`);
   }
 
-  // remove the params with undefined values
-  Object.keys(params).forEach(key => params[key] === undefined && delete params[key])
   Logger.debug("Params", params, "OAuth2Utils");
   const url = new URL(baseUrl);
   const searchParams = new URLSearchParams(params);


### PR DESCRIPTION
## Describe your changes
Added Slack V2 OAuth2 integration to CMS.

We are requesting user token as we are operating on behalf of the user, so we pass `user_scope` instead of `scope` when we request for authorization.
By default. the token rotation is disabled, which means the OAuth token never expires. When we enable it, a token only valid for 12 hours.

## Issue ticket number and link
FI-38

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics?
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.
